### PR TITLE
Fix for double slash issue

### DIFF
--- a/sitemaps.js
+++ b/sitemaps.js
@@ -30,7 +30,7 @@ app.use(function(req, res, next) {
       return next();
 
     urlStart = (req.headers['x-forwarded-proto'] || req.protocol || 'http')
-      + '://' + req.headers.host + '/';
+      + '://' + req.headers.host;
 
 		pages = sitemaps.list[req.url];
     if (_.isFunction(pages))
@@ -91,14 +91,16 @@ app.use(function(req, res, next) {
 
 sitemaps.add = function(url, func) {
   "use strict";
+  
+  var root = process.env.ROOT_URL;
 
   // don't double slash urls
   check(url, String);
   if (process.env.ROOT_URL.slice(-1) == '/' && url[0] == '/')
-    url = url.slice(1);
+    root = root.slice(0, -1);
 
   sitemaps.list[url] = func;
-  robots.addLine('Sitemap: ' + process.env.ROOT_URL + url);
+  robots.addLine('Sitemap: ' + root + url);
 };
 
 /*


### PR DESCRIPTION
Hey,

We were having an issue with your sitemaps package were url's in the sitemap were being double slashed, e.g `rooturl.com//foo.txt`.

This patch fixes it and should work regardless of whether your ROOT_URL has a / at the end or not.
