### PR TITLE
Multiple protocols reported by reverse proxy

### DIFF
--- a/sitemaps.js
+++ b/sitemaps.js
@@ -28,8 +28,8 @@ WebApp.connectHandlers.use(function(req, res, next) {
     urls = _.keys(sitemaps.list);
     if (!_.contains(urls, req.url))
       return next();
-
-    urlStart = (req.headers['x-forwarded-proto'] || req.protocol || 'http')
+  
+    urlStart = (req.headers['x-forwarded-proto'] || req.protocol || 'http').split(",")[0]
       + '://' + req.headers.host + '/';
 
 		pages = sitemaps.list[req.url];


### PR DESCRIPTION
Nginx/other proxies can sometimes use commas to report multiple protocols involved, e.g 'https,http' can be reported depending on the intermediary proxies.

This will get the first one only to conform to the sitemaps spec.
