### PR TITLE
Update package.js

### DIFF
--- a/package.js
+++ b/package.js
@@ -1,10 +1,12 @@
 Package.describe({
-    summary: "functions to easily output valid sitemaps"
+    summary: "functions to easily output valid sitemaps",
+    version: "0.0.18"
 });
 
 Package.on_use(function (api) {
-  api.use('webapp', 'server');
-	api.use('robots-txt', 'server');
+	if(api.versionsFrom) api.versionsFrom("METEOR-CORE@0.9.0-atm");
+	api.use('webapp', 'server');
+	api.use('gadicohen:robots-txt@0.0.8', 'server');
 	api.add_files('sitemaps.js', 'server');
 	
 	api.export('sitemaps', 'server');


### PR DESCRIPTION
Compatibility with 0.9.0

Because of line 9, can't be released via `mrt release`, only via `meteor publish`
