### PR TITLE
Add dependency on check package

### DIFF
--- a/package.js
+++ b/package.js
@@ -1,7 +1,7 @@
 Package.describe({
 	name: "gadicohen:sitemaps",
   summary: "functions to easily output valid sitemaps",
-  version: "0.0.20",
+  version: "0.0.21",
   git: 'https://github.com/gadicc/meteor-sitemaps.git'
 });
 
@@ -9,7 +9,7 @@ Package.on_use(function (api) {
   if(api.versionsFrom)
   	api.versionsFrom("METEOR@0.9.0");
 
-  api.use('webapp', 'server');
+  api.use('webapp', 'server', 'check');
   api.use('gadicohen:robots-txt@0.0.8', 'server');
 
   api.add_files('sitemaps.js', 'server');


### PR DESCRIPTION
The package uses `check` here: https://github.com/gadicc/meteor-sitemaps/blob/master/sitemaps.js#L132

So shouldn't it include the check package in its dependencies?